### PR TITLE
wait for VolumeSnapshotContents to have a snapshot handle during backup

### DIFF
--- a/velero-csi-plugin/util_test.go
+++ b/velero-csi-plugin/util_test.go
@@ -776,6 +776,7 @@ func TestGetVolumeSnapshotCalssForStorageClass(t *testing.T) {
 
 func TestGetVolumeSnapshotContentForVolumeSnapshot(t *testing.T) {
 	vscName := "snapcontent-7d1bdbd1-d10d-439c-8d8e-e1c2565ddc53"
+	snapshotHandle := "snapshot-handle"
 	vscObj := &snapshotv1beta1api.VolumeSnapshotContent{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: vscName,
@@ -785,6 +786,9 @@ func TestGetVolumeSnapshotContentForVolumeSnapshot(t *testing.T) {
 				Name:       "vol-snap-1",
 				APIVersion: snapshotv1beta1api.SchemeGroupVersion.String(),
 			},
+		},
+		Status: &snapshotv1beta1api.VolumeSnapshotContentStatus{
+			SnapshotHandle: &snapshotHandle,
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Hopefully the comment explains why this is needed. For now I just reused the existing "wait" pattern from that func, though we'll need to add timeouts and maybe make some other changes to handle snapshot failures later too.