### PR TITLE
Label created VolumeSnapshots with the backup name

### DIFF
--- a/internal/backup/csi_snapshotter.go
+++ b/internal/backup/csi_snapshotter.go
@@ -135,7 +135,7 @@ func (p *CSISnapshotter) Execute(item runtime.Unstructured, backup *velerov1api.
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "velero-" + pvc.Name + "-",
 			Namespace:    pvc.Namespace,
-			Annotations: map[string]string{
+			Labels: map[string]string{
 				velerov1api.BackupNameLabel: backup.Name,
 			},
 		},


### PR DESCRIPTION
Velero core will query for VolumeSnapshots with the backup name, which
can't be done against an annotation, so put the backup name as a label
instead.

Prerequisite for https://github.com/vmware-tanzu/velero/pull/2323

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>