### PR TITLE
Set PVC storage requests if restore size is greater

### DIFF
--- a/internal/restore/pvc_action_test.go
+++ b/internal/restore/pvc_action_test.go
@@ -19,6 +19,7 @@ package restore
 import (
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	corev1api "k8s.io/api/core/v1"
@@ -226,6 +227,101 @@ func TestResetPVCSpec(t *testing.T) {
 			assert.NotNil(t, tc.pvc.Spec.DataSource, "expected change to Spec.DataSource missing")
 			assert.Equalf(t, tc.pvc.Spec.DataSource.Kind, "VolumeSnapshot", "expected change to Spec.DataSource.Kind missing, Want: VolumeSnapshot, Got: %s", tc.pvc.Spec.DataSource.Kind)
 			assert.Equalf(t, tc.pvc.Spec.DataSource.Name, tc.vsName, "expected change to Spec.DataSource.Name missing, Want: %s, Got: %s", tc.vsName, tc.pvc.Spec.DataSource.Name)
+		})
+	}
+}
+
+func TestResetPVCResourceRequest(t *testing.T) {
+	var storageReq50Mi, storageReq1Gi, cpuQty resource.Quantity
+
+	storageReq50Mi, err := resource.ParseQuantity("50Mi")
+	assert.NoError(t, err)
+	storageReq1Gi, err = resource.ParseQuantity("1Gi")
+	assert.NoError(t, err)
+	cpuQty, err = resource.ParseQuantity("100m")
+	assert.NoError(t, err)
+
+	testCases := []struct {
+		name                      string
+		pvc                       corev1api.PersistentVolumeClaim
+		restoreSize               resource.Quantity
+		expectedStorageRequestQty string
+	}{
+		{
+			name: "should set storage resource request from volumesnapshot, pvc has nil resource requests",
+			pvc: corev1api.PersistentVolumeClaim{
+				Spec: corev1api.PersistentVolumeClaimSpec{
+					Resources: corev1api.ResourceRequirements{
+						Requests: nil,
+					},
+				},
+			},
+			restoreSize:               storageReq50Mi,
+			expectedStorageRequestQty: "50Mi",
+		},
+		{
+			name: "should set storage resource request from volumesnapshot, pvc has empty resource requests",
+			pvc: corev1api.PersistentVolumeClaim{
+				Spec: corev1api.PersistentVolumeClaimSpec{
+					Resources: corev1api.ResourceRequirements{
+						Requests: corev1api.ResourceList{},
+					},
+				},
+			},
+			restoreSize:               storageReq50Mi,
+			expectedStorageRequestQty: "50Mi",
+		},
+		{
+			name: "should merge resource requests from volumesnapshot into pvc with no storage resource requests",
+			pvc: corev1api.PersistentVolumeClaim{
+				Spec: corev1api.PersistentVolumeClaimSpec{
+					Resources: corev1api.ResourceRequirements{
+						Requests: corev1api.ResourceList{
+							corev1api.ResourceCPU: cpuQty,
+						},
+					},
+				},
+			},
+			restoreSize:               storageReq50Mi,
+			expectedStorageRequestQty: "50Mi",
+		},
+		{
+			name: "should set storage resource request from volumesnapshot, pvc requests less storage",
+			pvc: corev1api.PersistentVolumeClaim{
+				Spec: corev1api.PersistentVolumeClaimSpec{
+					Resources: corev1api.ResourceRequirements{
+						Requests: corev1api.ResourceList{
+							corev1api.ResourceStorage: storageReq50Mi,
+						},
+					},
+				},
+			},
+			restoreSize:               storageReq1Gi,
+			expectedStorageRequestQty: "1Gi",
+		},
+		{
+			name: "should not set storage resource request from volumesnapshot, pvc requests more storage",
+			pvc: corev1api.PersistentVolumeClaim{
+				Spec: corev1api.PersistentVolumeClaimSpec{
+					Resources: corev1api.ResourceRequirements{
+						Requests: corev1api.ResourceList{
+							corev1api.ResourceStorage: storageReq1Gi,
+						},
+					},
+				},
+			},
+			restoreSize:               storageReq50Mi,
+			expectedStorageRequestQty: "1Gi",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			log := logrus.New().WithField("unit-test", tc.name)
+			setPVCStorageResourceRequest(&tc.pvc, tc.restoreSize, log)
+			expected, err := resource.ParseQuantity(tc.expectedStorageRequestQty)
+			assert.NoError(t, err)
+			assert.Equal(t, expected, tc.pvc.Spec.Resources.Requests[corev1api.ResourceStorage])
 		})
 	}
 }

--- a/internal/util/labels_annotations.go
+++ b/internal/util/labels_annotations.go
@@ -19,6 +19,7 @@ package util
 const (
 	VolumeSnapshotLabel              = "velero.io/volume-snapshot-name"
 	VolumeSnapshotHandleAnnotation   = "velero.io/csi-volumesnapshot-handle"
+	VolumeSnapshotRestoreSize        = "velero.io/vsi-volumesnapshot-restore-size"
 	CSIDriverNameAnnotation          = "velero.io/csi-driver-name"
 	CSIDeleteSnapshotSecretName      = "velero.io/csi-deletesnapshotsecret-name"
 	CSIDeleteSnapshotSecretNamespace = "velero.io/csi-deletesnapshotsecret-namespace"


### PR DESCRIPTION
Signed-off-by: Ashish Amarnath <ashisham@vmware.com>

Fixes #40 

While restoring a PVC, set the storage resource request of the PVC to the larger of the PVC's storage resource requests and the restore size of the volume snapshot.
