### PR TITLE
Allow cross-namespace restore of CSI snapshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ BIN ?= velero-plugin-for-csi
 
 BUILD_IMAGE ?= golang:1.13-stretch
 
-REGISTRY ?= velero
+REGISTRY ?= catalogicsoftware
 IMAGE_NAME ?= $(REGISTRY)/velero-plugin-for-csi
-TAG ?= dev
+TAG ?= v0.1.2.1
 
 IMAGE ?= $(IMAGE_NAME):$(TAG)
 


### PR DESCRIPTION
- Check for namespace mapping information.
- If there is a map, replace VolumeSnapshots namespace to the target namespace

Fixes KUBEDR-364

Fixes Issues these similar issues from Velero:
1. https://github.com/vmware-tanzu/velero/issues/2143
2. https://github.com/vmware-tanzu/velero-plugin-for-csi/issues/75