### PR TITLE
Allow cross-namespace restore of PVC's with CSI volumes

### DIFF
--- a/internal/restore/pvc_action.go
+++ b/internal/restore/pvc_action.go
@@ -97,6 +97,12 @@ func (p *PVCRestoreItemAction) Execute(input *velero.RestoreItemActionExecuteInp
 
 	resetPVCAnnotations(&pvc, []string{velerov1api.BackupNameLabel, util.VolumeSnapshotLabel})
 
+	// If cross-namespace restore is configured, change the namespace
+	// for PVC object to be restored
+	if val, ok := input.Restore.Spec.NamespaceMapping[pvc.GetNamespace()]; ok {
+		pvc.SetNamespace(val)
+	}
+
 	volumeSnapshotName, ok := pvc.Annotations[util.VolumeSnapshotLabel]
 	if !ok {
 		p.Log.Infof("Skipping PVCRestoreItemAction for PVC %s/%s, PVC does not have a CSI volumesnapshot.", pvc.Namespace, pvc.Name)

--- a/internal/restore/volumesnapshot_action.go
+++ b/internal/restore/volumesnapshot_action.go
@@ -63,6 +63,13 @@ func (p *VolumeSnapshotRestoreItemAction) Execute(input *velero.RestoreItemActio
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(input.Item.UnstructuredContent(), &vs); err != nil {
 		return &velero.RestoreItemActionExecuteOutput{}, errors.Wrapf(err, "failed to convert input.Item from unstructured")
 	}
+
+	// If cross-namespace restore is configured, change the namespace
+	// for VolumeSnapshot object to be restored
+	if val, ok := input.Restore.Spec.NamespaceMapping[vs.GetNamespace()]; ok {
+		vs.SetNamespace(val)
+	}
+
 	_, snapClient, err := util.GetClients()
 	if err != nil {
 		return nil, errors.WithStack(err)


### PR DESCRIPTION
- Check for presence of namespace mapping specification during Restore.
- If there is a valid mapping found, then, replace the original namespace in VolumeSnapshot and PVC Objects to the mapped namespace before restoring these objects.
- Fixes PR 2143(https://github.com/vmware-tanzu/velero/issues/2143)
- [TestResults.txt](https://github.com/vmware-tanzu/velero-plugin-for-csi/files/5672901/TestResults.txt)

Signed-off-by: Swanand Shende from Catalogic Software <sshende@catalogicsoftware.com>