### PR TITLE
Add ReadyToUse status check before assuming VolumeSnapshotContent ready.

### DIFF
--- a/changelogs/unreleased/100-jxun
+++ b/changelogs/unreleased/100-jxun
@@ -1,0 +1,1 @@
+Add ReadyToUse status check before assuming VolumeSnapshotContent ready.

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -39,6 +39,7 @@ import (
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/label"
 	"github.com/vmware-tanzu/velero/pkg/restic"
+	"github.com/vmware-tanzu/velero/pkg/util/boolptr"
 )
 
 const (
@@ -178,8 +179,8 @@ func GetVolumeSnapshotContentForVolumeSnapshot(volSnap *snapshotv1api.VolumeSnap
 		// we need to wait for the VolumeSnaphotContent to have a snapshot handle because during restore,
 		// we'll use that snapshot handle as the source for the VolumeSnapshotContent so it's statically
 		// bound to the existing snapshot.
-		if snapshotContent.Status == nil || snapshotContent.Status.SnapshotHandle == nil {
-			log.Infof("Waiting for volumesnapshotcontents %s to have snapshot handle. Retrying in %ds", snapshotContent.Name, interval/time.Second)
+		if snapshotContent.Status == nil || snapshotContent.Status.SnapshotHandle == nil || !boolptr.IsSetToTrue(snapshotContent.Status.ReadyToUse) {
+			log.Infof("Waiting for volumesnapshotcontents %s to have snapshot handle and turn ready. Retrying in %ds", snapshotContent.Name, interval/time.Second)
 			return false, nil
 		}
 

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -719,6 +719,7 @@ func TestGetVolumeSnapshotCalssForStorageClass(t *testing.T) {
 func TestGetVolumeSnapshotContentForVolumeSnapshot(t *testing.T) {
 	vscName := "snapcontent-7d1bdbd1-d10d-439c-8d8e-e1c2565ddc53"
 	snapshotHandle := "snapshot-handle"
+	snapshotStatus := true
 	vscObj := &snapshotv1api.VolumeSnapshotContent{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: vscName,
@@ -731,6 +732,7 @@ func TestGetVolumeSnapshotContentForVolumeSnapshot(t *testing.T) {
 		},
 		Status: &snapshotv1api.VolumeSnapshotContentStatus{
 			SnapshotHandle: &snapshotHandle,
+			ReadyToUse:     &snapshotStatus,
 		},
 	}
 	validVS := &snapshotv1api.VolumeSnapshot{


### PR DESCRIPTION
fix https://github.com/vmware-tanzu/velero/issues/4819

Signed-off-by: Xun Jiang <jxun@vmware.com>