### PR TITLE
support GA storage-provider annotation

### DIFF
--- a/internal/restore/pvc_action.go
+++ b/internal/restore/pvc_action.go
@@ -35,10 +35,11 @@ import (
 )
 
 const (
-	AnnBindCompleted      = "pv.kubernetes.io/bind-completed"
-	AnnBoundByController  = "pv.kubernetes.io/bound-by-controller"
-	AnnStorageProvisioner = "volume.beta.kubernetes.io/storage-provisioner"
-	AnnSelectedNode       = "volume.kubernetes.io/selected-node"
+	AnnBindCompleted          = "pv.kubernetes.io/bind-completed"
+	AnnBoundByController      = "pv.kubernetes.io/bound-by-controller"
+	AnnStorageProvisioner     = "volume.kubernetes.io/storage-provisioner"
+	AnnBetaStorageProvisioner = "volume.beta.kubernetes.io/storage-provisioner"
+	AnnSelectedNode           = "volume.kubernetes.io/selected-node"
 )
 
 // PVCRestoreItemAction is a restore item action plugin for Velero
@@ -102,7 +103,7 @@ func (p *PVCRestoreItemAction) Execute(input *velero.RestoreItemActionExecuteInp
 	p.Log.Infof("Starting PVCRestoreItemAction for PVC %s/%s", pvc.Namespace, pvc.Name)
 
 	removePVCAnnotations(&pvc,
-		[]string{AnnBindCompleted, AnnBoundByController, AnnStorageProvisioner, AnnSelectedNode})
+		[]string{AnnBindCompleted, AnnBoundByController, AnnStorageProvisioner, AnnBetaStorageProvisioner, AnnSelectedNode})
 
 	// If cross-namespace restore is configured, change the namespace
 	// for PVC object to be restored


### PR DESCRIPTION
Hi, the storage-provider annotation "volume.kubernetes.io/storage-provisioner" is now GA, so it is necessary to delete it on restore as well. I noticed it when I tested to backup/restore Longhorn PVs. This was not possible without this change.

related issue: https://github.com/kubernetes/kubernetes/issues/102357