### PR TITLE
Build and publish multi-arch images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+Makefile
+_output
+velero-plugin-for-csi

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,5 +16,8 @@ jobs:
     - name: Check out the code
       uses: actions/checkout@v1
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
     - name: Make ci
       run: make ci

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,6 +24,9 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
     - name: Build
       run: make all
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+FROM --platform=$BUILDPLATFORM golang:1.17-stretch as build
+ARG TARGETOS
+ARG TARGETARCH
+
+COPY . .
+RUN GOPATH= GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o velero-plugin-for-csi .
+
 FROM busybox:1.33.1 AS busybox
 
 FROM scratch
-ADD velero-plugin-for-csi /plugins/
+
 COPY --from=busybox /bin/cp /bin/cp
+COPY --from=build /go/velero-plugin-for-csi /plugins/
+
 USER 65532:65532
 ENTRYPOINT ["cp", "/plugins/velero-plugin-for-csi", "/target/."]


### PR DESCRIPTION
This builds the binary as part of the Docker build process instead of copying the binary into the container. I've used this successfully and wanted to share if it would be useful.

Fixes https://github.com/vmware-tanzu/velero/issues/4303.