### PR TITLE
Support multiple snapshot classes per driver

### DIFF
--- a/internal/backup/pvc_action.go
+++ b/internal/backup/pvc_action.go
@@ -105,7 +105,7 @@ func (p *PVCBackupItemAction) Execute(item runtime.Unstructured, backup *velerov
 		return nil, nil, errors.Wrap(err, "error getting storage class")
 	}
 	p.Log.Debugf("Fetching volumesnapshot class for %s", storageClass.Provisioner)
-	snapshotClass, err := util.GetVolumeSnapshotClassForStorageClass(storageClass.Provisioner, snapshotClient.SnapshotV1())
+	snapshotClass, err := util.GetVolumeSnapshotClassForStorageClass(storageClass.Provisioner, backup.Spec.VolumeSnapshotLocations, snapshotClient.SnapshotV1())
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to get volumesnapshotclass for storageclass %s", storageClass.Name)
 	}

--- a/internal/util/labels_annotations.go
+++ b/internal/util/labels_annotations.go
@@ -17,14 +17,15 @@ limitations under the License.
 package util
 
 const (
-	VolumeSnapshotLabel              = "velero.io/volume-snapshot-name"
-	VolumeSnapshotHandleAnnotation   = "velero.io/csi-volumesnapshot-handle"
-	VolumeSnapshotRestoreSize        = "velero.io/vsi-volumesnapshot-restore-size"
-	CSIDriverNameAnnotation          = "velero.io/csi-driver-name"
-	CSIDeleteSnapshotSecretName      = "velero.io/csi-deletesnapshotsecret-name"
-	CSIDeleteSnapshotSecretNamespace = "velero.io/csi-deletesnapshotsecret-namespace"
-	CSIVSCDeletionPolicy             = "velero.io/csi-vsc-deletion-policy"
-	VolumeSnapshotClassSelectorLabel = "velero.io/csi-volumesnapshot-class"
+	VolumeSnapshotLabel                 = "velero.io/volume-snapshot-name"
+	VolumeSnapshotHandleAnnotation      = "velero.io/csi-volumesnapshot-handle"
+	VolumeSnapshotRestoreSize           = "velero.io/vsi-volumesnapshot-restore-size"
+	CSIDriverNameAnnotation             = "velero.io/csi-driver-name"
+	CSIDeleteSnapshotSecretName         = "velero.io/csi-deletesnapshotsecret-name"
+	CSIDeleteSnapshotSecretNamespace    = "velero.io/csi-deletesnapshotsecret-namespace"
+	CSIVSCDeletionPolicy                = "velero.io/csi-vsc-deletion-policy"
+	VolumeSnapshotClassSelectorLabel    = "velero.io/csi-volumesnapshot-class"
+	VolumeSnapshotLocationSelectorLabel = "velero.io/csi-volumesnapshot-location"
 
 	// There is no release w/ these constants exported. Using the strings for now.
 	// CSI Labels volumesnapshotclass


### PR DESCRIPTION
The plugin currently only supports one VolumeSnapshotClass via the "velero.io/csi-volumesnapshot-class" label. If a driver has more than one VolumeSnapshotClass with this label, there is no way to control which one will be used for backups.

It's not unusual to have multiple snapshot classes -- e.g. one for in-cluster snapshots, another for off-site backups -- and it would be enormously convenient to be able to use the CSI plugin to drive backups for all such classes.

To that end, this change introduces a new label "velero.io/csi-volumesnapshot-location" applied to VolumeSnapshotClass. If the value of this label matches one of the VolumeSnapshotLocations used by the backup, then that VolumeSnapshotClass will be used. This allows the user to control which VolumeSnapshotClasses is used for a particular driver based on their choice of volume snapshot location.

Existing behavior is unchanged.