### PR TITLE
Add label to ignore specific StorageClasses from backup

### DIFF
--- a/internal/backup/pvc_action.go
+++ b/internal/backup/pvc_action.go
@@ -104,6 +104,12 @@ func (p *PVCBackupItemAction) Execute(item runtime.Unstructured, backup *velerov
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error getting storage class")
 	}
+
+	if _, ok := storageClass.Labels[util.IgnoreVolumeSnapshotLabel]; ok {
+		p.Log.Infof("Skipping PVC %s/%s, associated storage class %s has the ignore label set", pvc.Namespace, pvc.Name, storageClass.Name)
+		return item, nil, nil
+	}
+
 	p.Log.Debugf("Fetching volumesnapshot class for %s", storageClass.Provisioner)
 	snapshotClass, err := util.GetVolumeSnapshotClassForStorageClass(storageClass.Provisioner, snapshotClient.SnapshotV1())
 	if err != nil {

--- a/internal/util/labels_annotations.go
+++ b/internal/util/labels_annotations.go
@@ -25,6 +25,7 @@ const (
 	CSIDeleteSnapshotSecretNamespace = "velero.io/csi-deletesnapshotsecret-namespace"
 	CSIVSCDeletionPolicy             = "velero.io/csi-vsc-deletion-policy"
 	VolumeSnapshotClassSelectorLabel = "velero.io/csi-volumesnapshot-class"
+	IgnoreVolumeSnapshotLabel        = "velero.io/csi-volumesnapshot-ignore"
 
 	// There is no release w/ these constants exported. Using the strings for now.
 	// CSI Labels volumesnapshotclass


### PR DESCRIPTION
This fixes the issue described in https://github.com/vmware-tanzu/velero/issues/6051. Let me know if you think this approach makes sense. Also where would this need to be documented? It looks like the main docs for CSI are in the velero repo, so I guess that would be the proper place.