### PR TITLE
Bump the Golang version to v1.19 for the GCP plugin's main branch.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.18
+    - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19
       id: go
 
     - name: Check out the code

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.18
+    - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19
       id: go
 
     - name: Check out code into the Go module directory

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # The binary to build (just the basename).
 BIN ?= velero-plugin-for-csi
 
-BUILD_IMAGE ?= golang:1.18-bullseye
+BUILD_IMAGE ?= golang:1.19-bullseye
 
 REGISTRY ?= velero
 IMAGE_NAME ?= $(REGISTRY)/velero-plugin-for-csi

--- a/changelogs/unreleased/153-blackpiglet
+++ b/changelogs/unreleased/153-blackpiglet
@@ -1,0 +1,1 @@
+Bump the Golang version to v1.19 for the GCP plugin's main branch.


### PR DESCRIPTION
Bump the Golang version to v1.19 for the GCP plugin's main branch.