### PR TITLE
Clean PVC's DataSource and DataSourceRef by setting them to nil.

### DIFF
--- a/internal/restore/pvc_action.go
+++ b/internal/restore/pvc_action.go
@@ -125,8 +125,8 @@ func (p *PVCRestoreItemAction) Execute(input *velero.RestoreItemActionExecuteInp
 	if boolptr.IsSetToFalse(input.Restore.Spec.RestorePVs) {
 		p.Log.Infof("Restore did not request for PVs to be restored from snapshot %s/%s.", input.Restore.Namespace, input.Restore.Name)
 		pvc.Spec.VolumeName = ""
-		pvc.Spec.DataSource = &corev1api.TypedLocalObjectReference{}
-		pvc.Spec.DataSourceRef = &corev1api.TypedLocalObjectReference{}
+		pvc.Spec.DataSource = nil
+		pvc.Spec.DataSourceRef = nil
 	} else {
 		_, snapClient, err := util.GetClients()
 		if err != nil {


### PR DESCRIPTION
Setting `DataSource` and `DataSourceRef` to a empty structure cannot work.
Restore fails with PartiallyFailed

```shell
error restoring persistentvolumeclaims/upgrade/my-pvc: PersistentVolumeClaim "my-pvc" is invalid: [spec.dataSource.name: Required value, spec.dataSource.kind: Required value, spec.dataSource: Invalid value: "", spec.dataSourceRef.name: Required value, spec.dataSourceRef.kind: Required value, spec.dataSourceRef: Invalid value: ""]
``` 

```go
		pvc.Spec.DataSource = &corev1api.TypedLocalObjectReference{}
		pvc.Spec.DataSourceRef = &corev1api.TypedLocalObjectReference{}
``` 

Failed to find this in verification, because the testing workload's PV is not a CSI one.