### PR TITLE
Unify CSI plugin build process and bump golang version.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,5 @@
 name: Run CI
-on: [push, pull_request]
+on: [pull_request]
 jobs:
 
   build:
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.19
+        go-version: '1.20'
       id: go
 
     - name: Check out the code

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,17 +18,36 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.19
+        go-version: '1.20'
       id: go
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
     - name: Build
-      run: make all
+      run: make local
 
     - name: Test
       run: make test
+
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: all
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        version: latest
+
+    # Use the JSON key in secret to login gcr.io
+    - uses: 'docker/login-action@v2'
+      with:
+        registry: 'gcr.io' # or REGION.docker.pkg.dev
+        username: '_json_key'
+        password: '${{ secrets.GCR_SA_KEY }}'
    
     # Only try to publish the container image from the root repo; forks don't have permission to do so and will always get failures.
     - name: Publish container image

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,13 +15,20 @@
 # The binary to build (just the basename).
 BIN ?= velero-plugin-for-csi
 
-BUILD_IMAGE ?= golang:1.19-bullseye
+# This repo's root import path (under GOPATH).
+PKG := github.com/vmware-tanzu/$(BIN)
 
+# Where to push the docker image.
 REGISTRY ?= velero
-IMAGE_NAME ?= $(REGISTRY)/velero-plugin-for-csi
-TAG ?= dev
+GCR_REGISTRY ?= gcr.io/velero-gcp
 
-IMAGE ?= $(IMAGE_NAME):$(TAG)
+# Image name
+IMAGE?= $(REGISTRY)/$(BIN)
+GCR_IMAGE ?= $(GCR_REGISTRY)/$(BIN)
+
+# We allow the Dockerfile to be configurable to enable the use of custom Dockerfiles
+# that pull base images from different registries.
+VELERO_DOCKERFILE ?= Dockerfile
 
 # Which architecture to build - see $(ALL_ARCH) for options.
 # if the 'local' rule is being run, detect the ARCH from 'go env'
@@ -29,78 +36,94 @@ IMAGE ?= $(IMAGE_NAME):$(TAG)
 local : ARCH ?= $(shell go env GOOS)-$(shell go env GOARCH)
 ARCH ?= linux-amd64
 
+VERSION ?= main
+
+TAG_LATEST ?= false
+
+ifeq ($(TAG_LATEST), true)
+	IMAGE_TAGS ?= $(IMAGE):$(VERSION) $(IMAGE):latest
+	GCR_IMAGE_TAGS ?= $(GCR_IMAGE):$(VERSION) $(GCR_IMAGE):latest
+else
+	IMAGE_TAGS ?= $(IMAGE):$(VERSION)
+	GCR_IMAGE_TAGS ?= $(GCR_IMAGE):$(VERSION)
+endif
+
+ifeq ($(shell docker buildx inspect 2>/dev/null | awk '/Status/ { print $$2 }'), running)
+	BUILDX_ENABLED ?= true
+else
+	BUILDX_ENABLED ?= false
+endif
+
+define BUILDX_ERROR
+buildx not enabled, refusing to run this recipe
+see: https://velero.io/docs/main/build-from-source/#making-images-and-updating-velero for more info
+endef
+
+CLI_PLATFORMS ?= linux-amd64 linux-arm linux-arm64 darwin-amd64 darwin-arm64 windows-amd64 linux-ppc64le
+BUILDX_PLATFORMS ?= $(subst -,/,$(ARCH))
+BUILDX_OUTPUT_TYPE ?= docker
+
+# set git sha and tree state
+GIT_SHA = $(shell git rev-parse HEAD)
+ifneq ($(shell git status --porcelain 2> /dev/null),)
+	GIT_TREE_STATE ?= dirty
+else
+	GIT_TREE_STATE ?= clean
+endif
+
+###
+### These variables should not need tweaking.
+###
+
 platform_temp = $(subst -, ,$(ARCH))
 GOOS = $(word 1, $(platform_temp))
 GOARCH = $(word 2, $(platform_temp))
 GOPROXY ?= https://proxy.golang.org
 
-.PHONY: all
-all: $(addprefix build-, $(BIN))
-
-build-%:
-	$(MAKE) --no-print-directory BIN=$* build
-
 .PHONY: local
 local: build-dirs
 	GOOS=$(GOOS) \
 	GOARCH=$(GOARCH) \
-	GOPROXY=$(GOPROXY) \
+	VERSION=$(VERSION) \
+	REGISTRY=$(REGISTRY) \
+	PKG=$(PKG) \
 	BIN=$(BIN) \
+	GIT_SHA=$(GIT_SHA) \
+	GIT_TREE_STATE=$(GIT_TREE_STATE) \
 	OUTPUT_DIR=$$(pwd)/_output/bin/$(GOOS)/$(GOARCH) \
 	./hack/build.sh
 
-build: _output/bin/$(GOOS)/$(GOARCH)/$(BIN)
+.PHONY: container
+container:
+ifneq ($(BUILDX_ENABLED), true)
+	$(error $(BUILDX_ERROR))
+endif
+	@docker buildx build --pull \
+	--output=type=$(BUILDX_OUTPUT_TYPE) \
+	--platform $(BUILDX_PLATFORMS) \
+	$(addprefix -t , $(IMAGE_TAGS)) \
+	$(addprefix -t , $(GCR_IMAGE_TAGS)) \
+	--build-arg=GOPROXY=$(GOPROXY) \
+	--build-arg=PKG=$(PKG) \
+	--build-arg=BIN=$(BIN) \
+	--build-arg=VERSION=$(VERSION) \
+	--build-arg=GIT_SHA=$(GIT_SHA) \
+	--build-arg=GIT_TREE_STATE=$(GIT_TREE_STATE) \
+	--build-arg=REGISTRY=$(REGISTRY) \
+	-f $(VELERO_DOCKERFILE) .
+	@echo "container: $(IMAGE):$(VERSION)"
 
-_output/bin/$(GOOS)/$(GOARCH)/$(BIN): build-dirs
-	@echo "building: $@"
-	$(MAKE) shell CMD="-c '\
-		GOOS=$(GOOS) \
-		GOARCH=$(GOARCH) \
-		GOPROXY=$(GOPROXY) \
-		BIN=$(BIN) \
-		OUTPUT_DIR=/output/$(GOOS)/$(GOARCH) \
-		./hack/build.sh'"
+# test runs unit tests using 'go test' in the local environment.
+.PHONY: test
+test:
+	CGO_ENABLED=0 go test -v -coverprofile=coverage.out -timeout 60s ./...
 
-TTY := $(shell tty -s && echo "-t")
-
-shell: build-dirs 
-	@echo "running docker: $@"
-	@docker run \
-		-e GOFLAGS \
-		-i $(TTY) \
-		--rm \
-		-u $$(id -u):$$(id -g) \
-		-v "$$(pwd)/_output/bin:/output:delegated" \
-		-v $$(pwd)/.go/pkg:/go/pkg \
-		-v $$(pwd)/.go/src:/go/src \
-		-v $$(pwd)/.go/std:/go/std \
-		-v $$(pwd):/go/src/velero-plugin-for-csi \
-		-v $$(pwd)/.go/std/$(GOOS)_$(GOARCH):/usr/local/go/pkg/$(GOOS)_$(GOARCH)_static \
-		-v "$$(pwd)/.go/go-build:/.cache/go-build:delegated" \
-		-e CGO_ENABLED=0 \
-		-w /go/src/velero-plugin-for-csi \
-		$(BUILD_IMAGE) \
-		/bin/sh $(CMD)
+.PHONY: ci
+ci: verify-modules test
 
 build-dirs:
 	@mkdir -p _output/bin/$(GOOS)/$(GOARCH)
 	@mkdir -p .go/src/$(PKG) .go/pkg .go/bin .go/std/$(GOOS)/$(GOARCH) .go/go-build
-
-.PHONY: container
-container: all build-dirs
-	cp Dockerfile _output/bin/$(GOOS)/$(GOARCH)/Dockerfile
-	docker build -t $(IMAGE) -f _output/bin/$(GOOS)/$(GOARCH)/Dockerfile _output/bin/$(GOOS)/$(GOARCH)
-
-.PHONY: push
-push: container
-ifeq ($(TAG_LATEST), true)
-	docker tag $(IMAGE_NAME):$(TAG) $(IMAGE_NAME):latest
-	docker push $(IMAGE_NAME):latest
-endif
-	docker push $(IMAGE)
-
-.PHONY: all-ci
-all-ci: $(addprefix ci-, $(BIN))
 
 .PHONY: modules
 modules:
@@ -111,17 +134,6 @@ verify-modules: modules
 	@if !(git diff --quiet HEAD -- go.sum go.mod); then \
 		echo "go module files are out of date, please commit the changes to go.mod and go.sum"; exit 1; \
 	fi
-
-ci-%:
-	$(MAKE) --no-print-directory BIN=$* ci
-
-.PHONY: test
-test: build-dirs
-	@$(MAKE) shell  CMD="-c 'go test -timeout 30s -v -cover ./...'"
-
-.PHONY: ci
-ci: verify-modules all test
-	IMAGE=velero-plugin-for-csi:pr-verify $(MAKE) container
 
 changelog:
 	hack/release-tools/changelog.sh

--- a/README.md
+++ b/README.md
@@ -30,11 +30,10 @@ Below is a listing of plugin versions and respective Velero versions that are co
 
 | Plugin Version  | Velero Version |
 |-----------------|----------------|
+| v0.5.x          | v1.11.x        |
 | v0.4.x          | v1.10.x        |
 | v0.3.0          | v1.9.x         |
 | v0.2.0          | v1.7.x, v1.8.x |
-| v0.1.2          | v1.5.x, v1.6.x |
-| v0.1.1          | v1.4.x         |
 
 ## Filing issues
 

--- a/changelogs/unreleased/165-blackpiglet
+++ b/changelogs/unreleased/165-blackpiglet
@@ -1,0 +1,1 @@
+Unify CSI plugin build process and bump golang version.

--- a/hack/docker-push.sh
+++ b/hack/docker-push.sh
@@ -76,13 +76,25 @@ else
     fi
 fi
 
+if [[ -z "$BUILDX_PLATFORMS" ]]; then
+    BUILDX_PLATFORMS="linux/amd64,linux/arm64,linux/arm/v7"
+fi
+
 # Debugging info
 echo "Highest tag found: $HIGHEST"
 echo "BRANCH: $BRANCH"
 echo "TAG: $TAG"
 echo "TAG_LATEST: $TAG_LATEST"
 echo "VERSION: $VERSION"
+echo "BUILDX_PLATFORMS: $BUILDX_PLATFORMS"
 
 echo "Building and pushing container images."
 
-TAG="$VERSION" TAG_LATEST="$TAG_LATEST" make push
+# The use of "registry" as the buildx output type below instructs
+# Docker to push the image
+
+VERSION="$VERSION" \
+TAG_LATEST="$TAG_LATEST" \
+BUILDX_PLATFORMS="$BUILDX_PLATFORMS" \
+BUILDX_OUTPUT_TYPE="registry" \
+make container

--- a/internal/restore/pvc_action.go
+++ b/internal/restore/pvc_action.go
@@ -125,8 +125,8 @@ func (p *PVCRestoreItemAction) Execute(input *velero.RestoreItemActionExecuteInp
 	if boolptr.IsSetToFalse(input.Restore.Spec.RestorePVs) {
 		p.Log.Infof("Restore did not request for PVs to be restored from snapshot %s/%s.", input.Restore.Namespace, input.Restore.Name)
 		pvc.Spec.VolumeName = ""
-		pvc.Spec.DataSource = &corev1api.TypedLocalObjectReference{}
-		pvc.Spec.DataSourceRef = &corev1api.TypedLocalObjectReference{}
+		pvc.Spec.DataSource = nil
+		pvc.Spec.DataSourceRef = nil
 	} else {
 		_, snapClient, err := util.GetClients()
 		if err != nil {


### PR DESCRIPTION
Unify the CSI plugin build process.
Bump the Golang version to v1.20.
Update the compatibility box in the README file.
Add pushing the image to gcr.io in action.
Modify  CI action trigger condition.

Fix https://github.com/vmware-tanzu/velero/issues/6146