### PR TITLE
Cleanup CSI Snapshots post Polling of VSC times out in CSI Plugin.

### DIFF
--- a/internal/backup/volumesnapshot_action.go
+++ b/internal/backup/volumesnapshot_action.go
@@ -92,6 +92,7 @@ func (p *VolumeSnapshotBackupItemAction) Execute(item runtime.Unstructured, back
 
 	vsc, err := util.GetVolumeSnapshotContentForVolumeSnapshot(&vs, snapshotClient.SnapshotV1(), p.Log, backupOngoing)
 	if err != nil {
+		util.CleanupVolumeSnapshot(&vs, snapshotClient.SnapshotV1(), p.Log)
 		return nil, nil, errors.WithStack(err)
 	}
 


### PR DESCRIPTION
Fix for the issue [Cleanup CSI Snapshots post Polling of VSC times out in CSI Plugin. #6219](https://github.com/vmware-tanzu/velero/issues/6219)