### PR TITLE
Use CSISnapshotTimeout to set the snapshot timeout

### DIFF
--- a/internal/backup/volumesnapshot_action.go
+++ b/internal/backup/volumesnapshot_action.go
@@ -95,7 +95,7 @@ func (p *VolumeSnapshotBackupItemAction) Execute(item runtime.Unstructured, back
 
 	p.Log.Infof("Getting VolumesnapshotContent for Volumesnapshot %s/%s", vs.Namespace, vs.Name)
 
-	vsc, err := util.GetVolumeSnapshotContentForVolumeSnapshot(&vs, snapshotClient.SnapshotV1(), p.Log, backupOngoing)
+	vsc, err := util.GetVolumeSnapshotContentForVolumeSnapshot(&vs, snapshotClient.SnapshotV1(), p.Log, backupOngoing, backup.Spec.CSISnapshotTimeout.Duration)
 	if err != nil {
 		util.CleanupVolumeSnapshot(&vs, snapshotClient.SnapshotV1(), p.Log)
 		return nil, nil, "", nil, errors.WithStack(err)

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -918,7 +918,7 @@ func TestGetVolumeSnapshotContentForVolumeSnapshot(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualVSC, actualError := GetVolumeSnapshotContentForVolumeSnapshot(tc.volSnap, fakeClient.SnapshotV1(), logrus.New().WithField("fake", "test"), tc.wait)
+			actualVSC, actualError := GetVolumeSnapshotContentForVolumeSnapshot(tc.volSnap, fakeClient.SnapshotV1(), logrus.New().WithField("fake", "test"), tc.wait, 0)
 			if tc.expectError && actualError == nil {
 				assert.NotNil(t, actualError)
 				assert.Nil(t, actualVSC)


### PR DESCRIPTION
Here is a fix for the issue where CSISnapshotTimeout is not getting used by the plugin as reported here:
https://github.com/vmware-tanzu/velero/issues/6261

I ran these tests:
1. Edit snapshot-controller deployment to have 0 replicas so it would fail to create the snapshot.
Run a backup with CSISnapshotTimeout set to 1 minute and confirm from the log that timeout is honored.
2. Same test as above but without setting the CSISnapshotTimeout.  Timeout was 10 minutes as expected.
3. Let snapshot-controller deployment have 2 replicas and confirm that backup worked as normal.
4. Run "make test" and confirm that all tests passed.
