### PR TITLE
Remove VS name annotation from PVC during CSI restore

### DIFF
--- a/internal/restore/pvc_action.go
+++ b/internal/restore/pvc_action.go
@@ -122,6 +122,9 @@ func (p *PVCRestoreItemAction) Execute(input *velero.RestoreItemActionExecuteInp
 		}, nil
 	}
 
+	// remove the volumesnapshot name annotation as well
+	removePVCAnnotations(&pvc, []string{util.VolumeSnapshotLabel})
+
 	if boolptr.IsSetToFalse(input.Restore.Spec.RestorePVs) {
 		p.Log.Infof("Restore did not request for PVs to be restored from snapshot %s/%s.", input.Restore.Namespace, input.Restore.Name)
 		pvc.Spec.VolumeName = ""


### PR DESCRIPTION
Fixes https://github.com/vmware-tanzu/velero/issues/6361