### PR TITLE
Limit the label "velero.io/pvc-namespace-name" length to 63.

### DIFF
--- a/internal/backup/pvc_action.go
+++ b/internal/backup/pvc_action.go
@@ -172,7 +172,7 @@ func (p *PVCBackupItemAction) Execute(item runtime.Unstructured, backup *velerov
 	var itemToUpdate []velero.ResourceIdentifier
 
 	if boolptr.IsSetToTrue(backup.Spec.SnapshotMoveData) {
-		operationID = label.GetValidName(string(util.AsyncOperationIDPrefixDataUpload) + string(backup.UID) + "." + string(pvc.UID))
+		operationID = label.GetValidName(string(velerov1api.AsyncOperationIDPrefixDataUpload) + string(backup.UID) + "." + string(pvc.UID))
 		dataUploadLog := p.Log.WithFields(logrus.Fields{
 			"Source PVC":     fmt.Sprintf("%s/%s", pvc.Namespace, pvc.Name),
 			"VolumeSnapshot": fmt.Sprintf("%s/%s", upd.Namespace, upd.Name),
@@ -305,10 +305,10 @@ func newDataUpload(backup *velerov1api.Backup, vs *snapshotv1api.VolumeSnapshot,
 				},
 			},
 			Labels: map[string]string{
-				velerov1api.BackupNameLabel: label.GetValidName(backup.Name),
-				velerov1api.BackupUIDLabel:  string(backup.UID),
-				velerov1api.PVCUIDLabel:     string(pvc.UID),
-				util.AsyncOperationIDLabel:  operationID,
+				velerov1api.BackupNameLabel:       label.GetValidName(backup.Name),
+				velerov1api.BackupUIDLabel:        string(backup.UID),
+				velerov1api.PVCUIDLabel:           string(pvc.UID),
+				velerov1api.AsyncOperationIDLabel: operationID,
 			},
 		},
 		Spec: velerov2alpha1.DataUploadSpec{
@@ -342,7 +342,7 @@ func createDataUpload(ctx context.Context, backup *velerov1api.Backup, veleroCli
 
 func getDataUpload(ctx context.Context, backup *velerov1api.Backup,
 	veleroClient veleroClientSet.Interface, operationID string) (*velerov2alpha1.DataUpload, error) {
-	listOptions := metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", util.AsyncOperationIDLabel, operationID)}
+	listOptions := metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", velerov1api.AsyncOperationIDLabel, operationID)}
 
 	dataUploadList, err := veleroClient.VeleroV2alpha1().DataUploads(backup.Namespace).List(context.Background(), listOptions)
 	if err != nil {

--- a/internal/backup/pvc_action_test.go
+++ b/internal/backup/pvc_action_test.go
@@ -86,10 +86,10 @@ func TestExecute(t *testing.T) {
 					GenerateName: "test-",
 					Namespace:    "velero",
 					Labels: map[string]string{
-						velerov1api.BackupNameLabel: "test",
-						velerov1api.BackupUIDLabel:  "",
-						velerov1api.PVCUIDLabel:     "",
-						util.AsyncOperationIDLabel:  "du-.",
+						velerov1api.BackupNameLabel:       "test",
+						velerov1api.BackupUIDLabel:        "",
+						velerov1api.PVCUIDLabel:           "",
+						velerov1api.AsyncOperationIDLabel: "du-.",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -193,7 +193,7 @@ func TestProgress(t *testing.T) {
 					Namespace: "velero",
 					Name:      "testing",
 					Labels: map[string]string{
-						util.AsyncOperationIDLabel: "testing",
+						velerov1api.AsyncOperationIDLabel: "testing",
 					},
 				},
 				Status: velerov2alpha1.DataUploadStatus{
@@ -268,7 +268,7 @@ func TestCancel(t *testing.T) {
 					Namespace: "velero",
 					Name:      "testing",
 					Labels: map[string]string{
-						util.AsyncOperationIDLabel: "testing",
+						velerov1api.AsyncOperationIDLabel: "testing",
 					},
 				},
 			},
@@ -283,7 +283,7 @@ func TestCancel(t *testing.T) {
 					Namespace: "velero",
 					Name:      "testing",
 					Labels: map[string]string{
-						util.AsyncOperationIDLabel: "testing",
+						velerov1api.AsyncOperationIDLabel: "testing",
 					},
 				},
 				Spec: velerov2alpha1.DataUploadSpec{

--- a/internal/util/labels_annotations.go
+++ b/internal/util/labels_annotations.go
@@ -43,22 +43,6 @@ const (
 	// timeout value for backup to plugins.
 	ResourceTimeoutAnnotation = "velero.io/resource-timeout"
 
-	// AsyncOperationIDLabel is the label key used to identify the async operation ID
-	AsyncOperationIDLabel = "velero.io/async-operation-id"
-
-	// TODO: need to use Velero server side label after it's added.
-	// PVCNameLabel is the label key used to identify the the PVC's namespace and name.
-	// The format is <namespace>/<name>.
-	PVCNamespaceNameLabel = "velero.io/pvc-namespace-name"
-
 	// DynamicPVRestoreLabel is the label key for dynamic PV restore
 	DynamicPVRestoreLabel = "velero.io/dynamic-pv-restore"
-)
-
-// TODO: need to use Velero server side type after it's added.
-type AsyncOperationIDPrefix string
-
-const (
-	AsyncOperationIDPrefixDataDownload AsyncOperationIDPrefix = "dd-"
-	AsyncOperationIDPrefixDataUpload   AsyncOperationIDPrefix = "du-"
 )


### PR DESCRIPTION
* Limit label length to 63.
* Use the label const variables from the Velero repository.
* Add Velero resource usage label for DataUploadResult ConfigMap list query.
* Adjust UT accordingly.