### PR TITLE
Return PVC intact when CSI is not present in PVC spec

### DIFF
--- a/internal/restore/pvc_action.go
+++ b/internal/restore/pvc_action.go
@@ -167,7 +167,15 @@ func (p *PVCRestoreItemAction) Execute(input *velero.RestoreItemActionExecuteInp
 			}
 			logger.Infof("DataDownload %s/%s is created successfully.", dataDownload.Namespace, dataDownload.Name)
 		} else {
-			if err := restoreFromVolumeSnapshot(&pvc, p.SnapshotClient, logger); err != nil {
+			volumeSnapshotName, ok := pvc.Annotations[util.VolumeSnapshotLabel]
+			if !ok {
+				logger.Info("Skipping PVCRestoreItemAction for PVC , PVC does not have a CSI volumesnapshot.")
+				// Make no change in the input PVC.
+				return &velero.RestoreItemActionExecuteOutput{
+					UpdatedItem: input.Item,
+				}, nil
+			}
+			if err := restoreFromVolumeSnapshot(&pvc, p.SnapshotClient, volumeSnapshotName, logger); err != nil {
 				logger.Errorf("Failed to restore PVC from VolumeSnapshot.")
 				return nil, errors.WithStack(err)
 			}
@@ -385,13 +393,7 @@ func newDataDownload(restore *velerov1api.Restore, dataUploadResult *velerov2alp
 }
 
 func restoreFromVolumeSnapshot(pvc *corev1api.PersistentVolumeClaim, snapClient snapshotterClientSet.Interface,
-	logger logrus.FieldLogger) error {
-	volumeSnapshotName, ok := pvc.Annotations[util.VolumeSnapshotLabel]
-	if !ok {
-		logger.Info("Skipping PVCRestoreItemAction for PVC , PVC does not have a CSI volumesnapshot.")
-		return nil
-	}
-
+	volumeSnapshotName string, logger logrus.FieldLogger) error {
 	vs, err := snapClient.SnapshotV1().VolumeSnapshots(pvc.Namespace).Get(context.TODO(), volumeSnapshotName, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrapf(err, fmt.Sprintf("Failed to get Volumesnapshot %s/%s to restore PVC %s/%s", pvc.Namespace, volumeSnapshotName, pvc.Namespace, pvc.Name))

--- a/internal/restore/pvc_action_test.go
+++ b/internal/restore/pvc_action_test.go
@@ -567,6 +567,14 @@ func TestExecute(t *testing.T) {
 			expectedPVC: builder.ForPersistentVolumeClaim("velero", "testPVC").ObjectMeta(builder.WithAnnotations("velero.io/volume-snapshot-name", "testVS")).Result(),
 		},
 		{
+			name:        "Restore from VolumeSnapshot without volume-snapshot-name annotation",
+			backup:      builder.ForBackup("velero", "testBackup").Result(),
+			restore:     builder.ForRestore("velero", "testRestore").Backup("testBackup").Result(),
+			pvc:         builder.ForPersistentVolumeClaim("velero", "testPVC").ObjectMeta(builder.WithAnnotations(AnnSelectedNode, "node1")).Result(),
+			vs:          builder.ForVolumeSnapshot("velero", "testVS").ObjectMeta(builder.WithAnnotations(util.VolumeSnapshotRestoreSize, "10Gi")).Result(),
+			expectedPVC: builder.ForPersistentVolumeClaim("velero", "testPVC").ObjectMeta(builder.WithAnnotations(AnnSelectedNode, "node1")).Result(),
+		},
+		{
 			name:        "DataUploadResult cannot be found",
 			backup:      builder.ForBackup("velero", "testBackup").SnapshotMoveData(true).Result(),
 			restore:     builder.ForRestore("velero", "testRestore").Backup("testBackup").Result(),


### PR DESCRIPTION
Return PVC intact when CSI is not present in PVC spec to avoid deleting useful annotations: when backing up and restoring with FileSystem, and installing the Velero CSI plugin alongside, changing the PVC's node-selector by ConfigMap can trigger this issue.
