### PR TITLE
Resolve conflict with PR #180

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ site/vendor
 .vs
 
 _tiltbuild
+coverage.out

--- a/internal/restore/pvc_action.go
+++ b/internal/restore/pvc_action.go
@@ -170,7 +170,7 @@ func (p *PVCRestoreItemAction) Execute(input *velero.RestoreItemActionExecuteInp
 			}
 			logger.Infof("DataDownload %s/%s is created successfully.", dataDownload.Namespace, dataDownload.Name)
 		} else {
-			volumeSnapshotName, ok := pvc.Annotations[util.VolumeSnapshotLabel]
+			volumeSnapshotName, ok := pvcFromBackup.Annotations[util.VolumeSnapshotLabel]
 			if !ok {
 				logger.Info("Skipping PVCRestoreItemAction for PVC , PVC does not have a CSI volumesnapshot.")
 				// Make no change in the input PVC.

--- a/internal/restore/pvc_action_test.go
+++ b/internal/restore/pvc_action_test.go
@@ -564,7 +564,7 @@ func TestExecute(t *testing.T) {
 				DataSourceRef(&corev1api.TypedLocalObjectReference{APIGroup: &snapshotv1api.SchemeGroupVersion.Group, Kind: util.VolumeSnapshotKindName, Name: "testVS"}).
 				Result(),
 			vs:          builder.ForVolumeSnapshot("velero", "testVS").ObjectMeta(builder.WithAnnotations(util.VolumeSnapshotRestoreSize, "10Gi")).Result(),
-			expectedPVC: builder.ForPersistentVolumeClaim("velero", "testPVC").ObjectMeta(builder.WithAnnotations("velero.io/volume-snapshot-name", "testVS")).Result(),
+			expectedPVC: builder.ForPersistentVolumeClaim("velero", "testPVC").Result(),
 		},
 		{
 			name:        "Restore from VolumeSnapshot without volume-snapshot-name annotation",


### PR DESCRIPTION
Fix conflict with #180.
Plugin workflow determines whether to restore depends on PVC has the VolumeSnapshot annotation, so change to check the annotation from the pvcFromBackup, not the modified PVC.