### PR TITLE
Annotate the PVC for non CSI PV

### DIFF
--- a/internal/backup/pvc_action.go
+++ b/internal/backup/pvc_action.go
@@ -99,7 +99,11 @@ func (p *PVCBackupItemAction) Execute(item runtime.Unstructured, backup *velerov
 	}
 	if pv.Spec.PersistentVolumeSource.CSI == nil {
 		p.Log.Infof("Skipping PVC %s/%s, associated PV %s is not a CSI volume", pvc.Namespace, pvc.Name, pv.Name)
-		return item, nil, "", nil, nil
+		util.AddAnnotations(&pvc.ObjectMeta, map[string]string{
+			util.SkippedNoCSIPVAnnotation: "true",
+		})
+		data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&pvc)
+		return &unstructured.Unstructured{Object: data}, nil, "", nil, err
 	}
 
 	// Do nothing if FS uploader is used to backup this PV

--- a/internal/util/labels_annotations.go
+++ b/internal/util/labels_annotations.go
@@ -40,7 +40,9 @@ const (
 
 	// Velero checks this annotation to determine whether to skip resource excluding check.
 	MustIncludeAdditionalItemAnnotation = "backup.velero.io/must-include-additional-items"
-
+	// SkippedNoCSIPVAnnotation - Velero checks this annotation on processed PVC to
+	// find out if the snapshot was skipped b/c the PV is not provisioned via CSI
+	SkippedNoCSIPVAnnotation = "backup.velero.io/skipped-no-csi-pv"
 	// ResourceTimeoutAnnotation is the annotation key used to carry the global resoure
 	// timeout value for backup to plugins.
 	ResourceTimeoutAnnotation = "velero.io/resource-timeout"


### PR DESCRIPTION
This is needed for notifying the velero process about the reason the PV was skipped.