### PR TITLE
Change VolumeSnapshotClassDriverBackupAnnotationPrefix's separator fr…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.2
 	// TODO: need to use velero v1.12.0 after releasing.
-	github.com/vmware-tanzu/velero v0.0.0-20230630063030-84eca51d22c7
+	github.com/vmware-tanzu/velero v0.0.0-20230727074327-a6d79fc272a2
 	k8s.io/api v0.25.6
 	k8s.io/apimachinery v0.25.6
 	k8s.io/client-go v0.25.6

--- a/go.sum
+++ b/go.sum
@@ -658,8 +658,8 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/tg123/go-htpasswd v1.2.1 h1:i4wfsX1KvvkyoMiHZzjS0VzbAPWfxzI8INcZAKtutoU=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/vmware-tanzu/velero v0.0.0-20230630063030-84eca51d22c7 h1:w/KPz4EQwQaaXes4gEgjrFrvygVSjjUaDQnm7VggtZ8=
-github.com/vmware-tanzu/velero v0.0.0-20230630063030-84eca51d22c7/go.mod h1:URz7drKyNV58T6MuVdDH/iATs3/DorJI+IEVPZwdHZE=
+github.com/vmware-tanzu/velero v0.0.0-20230727074327-a6d79fc272a2 h1:9gv429q/2bu75G/agjXDPfwHdZCDDcyH91ryxFx/rb4=
+github.com/vmware-tanzu/velero v0.0.0-20230727074327-a6d79fc272a2/go.mod h1:nf1mFikxiN+rhWqpXe38Ut4xyh5ETqdbtk8Byh3+hDg=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -106,7 +106,7 @@ func IsPVCDefaultToFSBackup(pvcNamespace, pvcName string, podClient corev1client
 	}
 
 	for _, p := range pods {
-		vols := podvolume.GetVolumesByPod(&p, defaultVolumesToFsBackup)
+		vols, _ := podvolume.GetVolumesByPod(&p, defaultVolumesToFsBackup)
 		if len(vols) > 0 {
 			volName, err := GetPodVolumeNameForPVC(p, pvcName)
 			if err != nil {
@@ -171,7 +171,7 @@ func GetVolumeSnapshotClassFromPVCAnnotationsForDriver(pvc *corev1api.Persistent
 
 // GetVolumeSnapshotClassFromAnnotationsForDriver returns a VolumeSnapshotClass for the supplied volume provisioner/ driver name from the annotation of the backup
 func GetVolumeSnapshotClassFromBackupAnnotationsForDriver(backup *velerov1api.Backup, provisioner string, snapshotClasses *snapshotv1api.VolumeSnapshotClassList) (*snapshotv1api.VolumeSnapshotClass, error) {
-	annotationKey := fmt.Sprintf("%s/%s", VolumeSnapshotClassDriverBackupAnnotationPrefix, strings.ToLower(provisioner))
+	annotationKey := fmt.Sprintf("%s_%s", VolumeSnapshotClassDriverBackupAnnotationPrefix, strings.ToLower(provisioner))
 	snapshotClassName, ok := backup.ObjectMeta.Annotations[annotationKey]
 	if !ok {
 		return nil, nil

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -23,9 +23,9 @@ import (
 	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	snapshotFake "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned/fake"
 	"github.com/sirupsen/logrus"
-	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -178,7 +178,6 @@ func TestGetPodsUsingPVC(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pod1",
 				Namespace: "default",
-        
 			},
 			Spec: v1.PodSpec{
 				Volumes: []v1.Volume{
@@ -631,7 +630,7 @@ func TestGetVolumeSnapshotClass(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "foo",
 			Annotations: map[string]string{
-				"velero.io/csi-volumesnapshot-class/foo.csi.k8s.io": "foowithoutlabel",
+				"velero.io/csi-volumesnapshot-class_foo.csi.k8s.io": "foowithoutlabel",
 			},
 		},
 		Spec: velerov1api.BackupSpec{
@@ -642,7 +641,7 @@ func TestGetVolumeSnapshotClass(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "foo2",
 			Annotations: map[string]string{
-				"velero.io/csi-volumesnapshot-class/foo.csi.k8s.io": "foo2",
+				"velero.io/csi-volumesnapshot-class_foo.csi.k8s.io": "foo2",
 			},
 		},
 		Spec: velerov1api.BackupSpec{
@@ -654,7 +653,7 @@ func TestGetVolumeSnapshotClass(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "bar",
 			Annotations: map[string]string{
-				"velero.io/csi-volumesnapshot-class/bar.csi.k8s.io": "bar2",
+				"velero.io/csi-volumesnapshot-class_bar.csi.k8s.io": "bar2",
 			},
 		},
 		Spec: velerov1api.BackupSpec{


### PR DESCRIPTION
…om "/" to "_"

1. During k8s annotation key format limitation, there is only one "/" allowed. https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
2. Update referenced Velero tag in go.mod