### PR TITLE
do not change the namespace of pvc and vs in restore plugin directly

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -358,16 +358,13 @@ func AddLabels(o *metav1.ObjectMeta, vals map[string]string) {
 }
 
 // IsVolumeSnapshotExists returns whether a specific volumesnapshot object exists.
-func IsVolumeSnapshotExists(volSnap *snapshotv1api.VolumeSnapshot, snapshotClient snapshotter.SnapshotV1Interface) bool {
-	exists := false
-	if volSnap != nil {
-		vs, err := snapshotClient.VolumeSnapshots(volSnap.Namespace).Get(context.TODO(), volSnap.Name, metav1.GetOptions{})
-		if err == nil && vs != nil {
-			exists = true
-		}
+func IsVolumeSnapshotExists(ns, name string, snapshotClient snapshotter.SnapshotV1Interface) bool {
+	vs, err := snapshotClient.VolumeSnapshots(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	if err == nil && vs != nil {
+		return true
 	}
 
-	return exists
+	return false
 }
 
 func SetVolumeSnapshotContentDeletionPolicy(vscName string, csiClient snapshotter.SnapshotV1Interface) error {

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1560,16 +1560,11 @@ func TestIsVolumeSnapshotExists(t *testing.T) {
 			expected: false,
 			vs:       vsNotExists,
 		},
-		{
-			name:     "should not find a nil VolumeSnapshot object",
-			expected: false,
-			vs:       nil,
-		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := IsVolumeSnapshotExists(tc.vs, fakeClient.SnapshotV1())
+			actual := IsVolumeSnapshotExists(tc.vs.Namespace, tc.vs.Name, fakeClient.SnapshotV1())
 			assert.Equal(t, tc.expected, actual)
 		})
 	}


### PR DESCRIPTION
do not change the namespace of pvc and vs in restore plugin directly, because:
1. namespace is updated in velero resore process after all RIAs are finished
2. If the namespace is changed in a RIA, all the following RIAs will be affacted.