### PR TITLE
[cherry-pick][release-0.6]Use backup.Spec.CSISnapshotTimeout for DataDownload OperationTimeout.

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -55,19 +55,3 @@ jobs:
       run: |
         docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
         ./hack/docker-push.sh
-
-    # Use the JSON key in secret to login gcr.io
-    - uses: 'docker/login-action@v2'
-      with:
-        registry: 'gcr.io' # or REGION.docker.pkg.dev
-        username: '_json_key'
-        password: '${{ secrets.GCR_SA_KEY }}'
-
-    # Push image to GCR to facilitate some environments that have rate limitation to docker hub, e.g. vSphere.
-    - name: Publish container image to GCR
-      if: github.repository == 'vmware-tanzu/velero-plugin-for-csi'
-      run: |
-        sudo swapoff -a
-        sudo rm -f /mnt/swapfile
-        docker image prune -a --force
-        REGISTRY=gcr.io/velero-gcp ./hack/docker-push.sh


### PR DESCRIPTION
Use backup.Spec.CSISnapshotTimeout for DataDownload OperationTimeout. Remove not needed pushing to GCR action.