### PR TITLE
Fix panic when csi timeout duration is short

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -268,7 +268,7 @@ func GetVolumeSnapshotContentForVolumeSnapshot(volSnap *snapshotv1api.VolumeSnap
 
 	if err != nil {
 		if err == wait.ErrWaitTimeout {
-			if snapshotContent.Status != nil && snapshotContent.Status.Error != nil {
+			if snapshotContent != nil && snapshotContent.Status != nil && snapshotContent.Status.Error != nil {
 				log.Errorf("Timed out awaiting reconciliation of volumesnapshot, Volumesnapshotcontent %s has error: %v", snapshotContent.Name, *snapshotContent.Status.Error.Message)
 				return nil, errors.Errorf("CSI got timed out with error: %v", *snapshotContent.Status.Error.Message)
 			} else {


### PR DESCRIPTION
CSI plugin panics on nil pointer when csiSnapshotTimeout is set to a short duration.

for example when csiSnapshotTimeout: 0m1s, we get:

`time="2023-11-13T09:22:01Z" level=error msg="Error backing up item" backup=openshift-adp/b13 error="error executing custom action (groupResource=persistentvolumeclaims, namespace=a1, name=mysql-1): rpc error: code = Aborted desc = plugin panicked: runtime error: invalid memory address or nil pointer dereference, stack trace: goroutine 116 [running]:\nruntime/debug.Stack()\n\t/usr/lib/golang/src/runtime/debug/stack.go:24 +0x65\ngithub.com/vmware-tanzu/velero/pkg/plugin/framework/common.HandlePanic({0x1f127e0, 0x3736c90})\n\t/remote-source/deps/gomod/pkg/mod/github.com/vmware-tanzu/velero@v1.12.0/pkg/plugin/framework/common/handle_panic.go:43 +0x91\ngithub.com/vmware-tanzu/velero/pkg/plugin/framework/backupitemaction/v2.(*BackupItemActionGRPCServer).Execute.func1()\n\t/remote-source/deps/gomod/pkg/mod/github.com/vmware-tanzu/velero@v1.12.0/pkg/plugin/framework/backupitemaction/v2/backup_item_action_server.go:90 +0x2c\npanic({0x1f127e0, 0x3736c90})\n\t/usr/lib/golang/src/runtime/panic.go:884 +0x213\ngithub.com/vmware-tanzu/velero-plugin-for-csi/internal/util.GetVolumeSnapshotContentForVolumeSnapshot(0xc000306500, {0x271de80?, 0xc00039e020}, {0x2735f10, 0xc0005e8f50}, 0xf8?, 0x3b9aca00)\n\t/remote-source/app/internal/util/util.go:269 +0x298\ngithub.com/vmware-tanzu/velero-plugin-for-csi/internal/backup.(*PVCBackupItemAction).Execute(0xc000415240, {0x2724430, 0xc000436388}, 0xc000aaae00)\n\t/remote-source/app/internal/backup/pvc_action.go:188 +0x1bb5\ngithub.com/vmware-tanzu/velero/pkg/plugin/framework/backupitemaction/v2.(*BackupItemActionGRPCServer).Execute(0x2097620?, {0xc0009b8460?, 0x51a0a6?}, 0xc0009b8460)\n\t/remote-source/deps/gomod/pkg/mod/github.com/vmware-tanzu/velero@v1.12.0/pkg/plugin/framework/backupitemaction/v2/backup_item_action_server.go:110 +0x366\ngithub.com/vmware-tanzu/velero/pkg/plugin/generated/backupitemaction/v2._BackupItemAction_Execute_Handler({0x2011640?, 0xc000731498}, {0x271dba8, 0xc0005bc5d0}, 0xc0009b83f0, 0x0)\n\t/remote-source/deps/gomod/pkg/mod/github.com/vmware-tanzu/velero@v1.12.0/pkg/plugin/generated/backupitemaction/v2/BackupItemAction.pb.go:794 +0x170\ngoogle.golang.org/grpc.(*Server).processUnaryRPC(0xc0004cc3c0, {0x2727198, 0xc000682820}, 0xc000b430e0, 0xc000988ba0, 0x3746818, 0x0)\n\t/remote-source/deps/gomod/pkg/mod/google.golang.org/grpc@v1.54.0/server.go:1345 +0xdf3\ngoogle.golang.org/grpc.(*Server).handleStream(0xc0004cc3c0, {0x2727198, 0xc000682820}, 0xc000b430e0, 0x0)\n\t/remote-source/deps/gomod/pkg/mod/google.golang.org/grpc@v1.54.0/server.go:1722 +0xa36\ngoogle.golang.org/grpc.(*Server).serveStreams.func1.2()\n\t/remote-source/deps/gomod/pkg/mod/google.golang.org/grpc@v1.54.0/server.go:966 +0x98\ncreated by google.golang.org/grpc.(*Server).serveStreams.func1\n\t/remote-source/deps/gomod/pkg/mod/google.golang.org/grpc@v1.54.0/server.go:964 +0x28a\n" error.file="/remote-source/velero/app/pkg/backup/item_backupper.go:366" error.function="github.com/vmware-tanzu/velero/pkg/backup.(*itemBackupper).executeActions" logSource="/remote-source/velero/app/pkg/backup/backup.go:448" name=mysql-1`