### PR TITLE
Set operation progress update time for VS BIA on completion.

### DIFF
--- a/internal/backup/volumesnapshot_action.go
+++ b/internal/backup/volumesnapshot_action.go
@@ -271,10 +271,14 @@ func (p *VolumeSnapshotBackupItemAction) Progress(operationID string, backup *ve
 			return progress, nil
 		}
 
+		now := time.Now()
+
 		if boolptr.IsSetToTrue(vsc.Status.ReadyToUse) {
 			progress.Completed = true
+			progress.Updated = now
 		} else if vsc.Status.Error != nil {
 			progress.Completed = true
+			progress.Updated = now
 			if vsc.Status.Error.Message != nil {
 				progress.Err = *vsc.Status.Error.Message
 			}


### PR DESCRIPTION
This PR is part of https://github.com/vmware-tanzu/velero/pull/7554.
It set the VolumeSnapshot async operation's `Status.Updated` when the operation completes.